### PR TITLE
英数字の全角半角を同一視

### DIFF
--- a/app/content_scripts.js
+++ b/app/content_scripts.js
@@ -66,7 +66,7 @@ function clean(text) {
     return;
   }
   for (let i = 0; i < elms.length; i++) {
-    if (jadgeText(elms[i].textContent, text)) {
+    if (judgeText(elms[i].textContent, text)) {
       if (!elms[i].classList.contains(hideClass)) {
         elms[i].classList.add(hideClass);
         elms[i].setAttribute('style', 'display:none');
@@ -75,7 +75,7 @@ function clean(text) {
       let flag = false;
       for (let ii = 0; ii < words.length; ii++) {
         if (
-          jadgeText(elms[i].textContent, words[ii].trim())
+          judgeText(elms[i].textContent, words[ii].trim())
         ) {
           flag = true;
           break;
@@ -94,7 +94,7 @@ function clean(text) {
  * @param {string} text 除外する単語
  * @return {boolean}
  */
-function jadgeText(textContent, text) {
+function judgeText(textContent, text) {
   if (!textContent || !text) {
     return false;
   }

--- a/app/content_scripts.js
+++ b/app/content_scripts.js
@@ -3,6 +3,10 @@ let words = [];
 const hideClass = 'yne_hide';
 const keyName = 'yne_words';
 
+String.prototype.zenkakuToHankaku = function() {
+  return this.replace(/[Ａ-Ｚａ-ｚ０-９]/g, (s) => String.fromCharCode(s.charCodeAt(0) - 0xFEE0));
+};
+
 chrome.storage.local.get([keyName], function(result) {
   if (typeof result[keyName] !== 'undefined') {
     words = JSON.parse(result[keyName]);
@@ -94,9 +98,7 @@ function jadgeText(textContent, text) {
   if (!textContent || !text) {
     return false;
   }
-  if (textContent.toLowerCase().indexOf(text.toLocaleLowerCase()) !== -1) {
-    return true;
-  }
+  return (textContent.toLocaleLowerCase().zenkakuToHankaku().indexOf(text.toLocaleLowerCase().zenkakuToHankaku()) !== -1);
 }
 
 chrome.storage.onChanged.addListener(function(changes, namespace) {


### PR DESCRIPTION
ニュースの配信社によって同じ単語が全角で書かれたり半角で書かれたりするため、除外ワード判定において、英数字の全角半角を同一視するようにしてみました。